### PR TITLE
fix: issue with signed aws uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,19 @@ docker compose rm supervisor
 docker compose up -d
 ```
 
+## Using AWS Signed URL uploads
+
+AWS supports creating a pre-signed url that can then be used to upload files to a specific predefined location, example: `tmp/`. Using this feature with minio as-is is not possible because when the `shld-core` core container listens to `http://minio:9010/*` it understands that the request is for the minio service's container. But when the `http://minio:9010/*` signed url is opened in your browser it dosen't know what this host is. For this we need to update the hosts file (generally located at `/etc/hosts` in linux) to understand `minio -> 127.0.0.1`.
+- For Linux Users, edit the hosts file at `/etc/hosts` (you can run `sudo nano /etc/hosts` in terminal) and add this line:
+  ```
+  127.0.0.1       minio
+  ```
+- For Mac Users, edit the hosts file located at `/private/etc/hosts` (you can run `sudo nano /private/etc/hosts` in your terminal) and add this line:
+  ```
+  127.0.0.1       minio
+  ```
+- For Windows users it is recomended to use [PowerToys](https://learn.microsoft.com/en-us/windows/powertoys/). It includes a great [Hosts file editor](https://learn.microsoft.com/en-us/windows/powertoys/hosts-file-editor) tool for easier hosts editing.
+
 ## Conatiners
 
 ```sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -167,7 +167,7 @@ services:
         image: 'minio/minio:latest'
         container_name: shld-minio
         ports:
-            - '${FORWARD_MINIO_PORT:-9000}:9000'
+            - '${FORWARD_MINIO_PORT:-9010}:9010'
             - '${FORWARD_MINIO_CONSOLE_PORT:-8900}:8900'
         environment:
             MINIO_ROOT_USER: ${MINIO_ROOT_USER}
@@ -186,7 +186,7 @@ services:
             - 'shld-minio:/data/minio'
         networks:
             - shld
-        command: minio server /data/minio --console-address ":8900"
+        command: minio server /data/minio --console-address ":8900" --address ":9010"
         healthcheck:
             test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
             interval: 10s

--- a/example.env
+++ b/example.env
@@ -2,7 +2,9 @@ BUILD_RUNTIME=8.1
 # NOTE: TRAEFIK_DASH != APP_HOST
 TRAEFIK_DASH=traefik.localhost
 APP_HOST=localhost
-MINIO_HOST="${APP_HOST}"
+# The hosts file should be updated to add "minio -> 127.0.0.1"
+# This is needed only if you are using signed uploads
+MINIO_HOST="minio"
 
 FORWARD_DB_PORT=3306
 DB_USERNAME=laravel

--- a/shld_command.sh
+++ b/shld_command.sh
@@ -49,6 +49,8 @@ shld_service () {
             case "$2" in
                 -h|--help)
                     shld_help_header
+                    echo "Bring up the docker containers by running."
+                    echo " "
                     echo "shld up [options]"
                     echo "EXAMPLE:"
                     echo -e "\t shld up -b \n\t shld up -r \n\t shld up -h"
@@ -86,6 +88,22 @@ shld_service () {
             append+=( --force-recreate )
         fi
     elif [[ "$1" == "down" || "$1" == "d" ]]; then
+        while test $# -gt 0; do
+            case "$2" in
+                -h|--help)
+                    shld_help_header
+                    echo "Shutdown (gracefully) and remove the docker containers"
+                    echo " "
+                    echo "shld down [options]"
+                    echo "EXAMPLE:"
+                    echo -e "\t shld down \n\t shld down -h"
+                    echo " "
+                    echo "options:"
+                    echo "-h, --help                shows this help"
+                    return
+                    ;;
+            esac
+        done
         shift $(expr $OPTIND + 1 )
         docker_cmd=(docker)
         service=(compose)
@@ -93,6 +111,22 @@ shld_service () {
         append=()
         # append=("$@")
     elif [[ "$1" == "ps" ]]; then
+        while test $# -gt 0; do
+            case "$2" in
+                -h|--help)
+                    shld_help_header
+                    echo "List all the created and running docker containers"
+                    echo " "
+                    echo "shld down [options]"
+                    echo "EXAMPLE:"
+                    echo -e "\t shld down \n\t shld down -h"
+                    echo " "
+                    echo "options:"
+                    echo "-h, --help                shows this help"
+                    return
+                    ;;
+            esac
+        done
         docker_cmd=(docker)
         service=(compose)
         executable=(ps)


### PR DESCRIPTION
## Describe your changes

This enables the use of AWS Signed URLs for Uploading using minio on localhost.

## Issue ticket number and link (if available)
N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have updated the `README.md` File (if needed).
- [x] Will this be part of a product update? If yes, please write one phrase about this update.

## Description (AI)

* **Change in Shld-Minio Service's Port and Command**
The technical configuration for assigning communication ports to 'shld-minio', a key component of our application, has been updated. Previously, it was using port number 9000, which may have been conflicted with other system processes. Now, it will use port number 9010, reducing the chances of conflicts and enhancing the overall system stability.
* **Updated MINIO_HOST value**
We have adjusted an important configuration setting within our system (`MINIO_HOST`). It has been changed from a value that represents the standard host address for the app to a specific label "minio". This update helps system components interact more effectively with the MinIO service, a crucial component responsible for efficiently handling storage tasks.
* **Improved SHLD Service Function**
The 'shld_service' function, a piece of our system which helps control certain operations, has been updated to provide better instructions for specific commands. Now, there will be help messages for the 'up', 'down', and 'ps' commands. This enhancement gives users a better understanding of what these commands do, resulting in a more user-friendly interface and enhancing the overall user experience.
