### PR TITLE
change: force minio to keep ports consistent

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Describe your changes
+<!-- A brief about what your PR fixes, changes or adds. -->
+
+
+## Issue ticket number and link (if available)
+<!-- Mention the GitHub/Jira Issue Number this PR addresses -->
+
+
+## Checklist before requesting a review
+- [ ] I have performed a self-review of my code
+- [ ] I have updated the `README.md` File (if needed).
+- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
+
+## Description (AI)
+
+wtd:summary

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -167,7 +167,7 @@ services:
         image: 'minio/minio:latest'
         container_name: shld-minio
         ports:
-            - '${FORWARD_MINIO_PORT:-9010}:9010'
+            - '${FORWARD_MINIO_PORT:-9010}:${FORWARD_MINIO_PORT:-9010}'
             - '${FORWARD_MINIO_CONSOLE_PORT:-8900}:8900'
         environment:
             MINIO_ROOT_USER: ${MINIO_ROOT_USER}
@@ -186,9 +186,9 @@ services:
             - 'shld-minio:/data/minio'
         networks:
             - shld
-        command: minio server /data/minio --console-address ":8900" --address ":9010"
+        command: minio server /data/minio --console-address ":8900" --address ":${FORWARD_MINIO_PORT:-9010}"
         healthcheck:
-            test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+            test: ["CMD", "curl", "-f", "http://localhost:${FORWARD_MINIO_PORT:-9010}/minio/health/live"]
             interval: 10s
             retries: 3
             timeout: 5s


### PR DESCRIPTION
## Describe your changes
<!-- A brief about what your PR fixes. -->
Enforce the minio service to use consistent ports to support aws pre-signed url uploads.

## Issue ticket number and link (if available)
<!-- Mention the GitHub/Jira Issue Number this PR addresses -->


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have updated the `README.md` File (if needed).
- [x] Will this be part of a product update? If yes, please write one phrase about this update.

## Description (AI)

* **Adjustments to Docker Service Configuration**
The `docker-compose.yml` configuration file has been updated to improve how the `shld-minio` service is managed. The main changes include:
    - Establishing dynamic mapping of the `FORWARD_MINIO_PORT` environment variable. This environment variable will now determine both the port for the `shld-minio` service on the local system and within its Docker container. This adds flexibility and eases setup.
    - The start command for the `shld-minio` service has been updated. Instead of using a fixed, hard-coded port number, it now uses the `FORWARD_MINIO_PORT` environment variable. This streamlines the configuration and allows for easier changes in the future.
    - The health check command for the `shld-minio` service has also been updated to use the `FORWARD_MINIO_PORT` environment variable, replacing the previously hard-coded port number. This strengthens the reliability of service checks and creates a more stable system monitoring.