### PR TITLE
Feat: Override yarn dev command from .env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
         environment:
             YARN_DEV_ONSTART: ${YARN_DEV_ONSTART:-true}
             YARN_DEV_RESTART: ${YARN_DEV_RESTART:-true}
+            YARN_DEV_COMMAND: ${YARN_DEV_COMMAND:-"yarn dev"}
             SCHEDULE_WORKER_ONSTART: ${SCHEDULE_WORKER_ONSTART:-true}
             SCHEDULE_WORKER_RESTART: ${SCHEDULE_WORKER_RESTART:-true}
             QUEUE_WORKER_ONSTART: ${QUEUE_WORKER_ONSTART:-true}

--- a/example.env
+++ b/example.env
@@ -40,6 +40,9 @@ FORWARD_ELASTICSEARCH_PORT=7700
 YARN_DEV_ONSTART=false
 # Will keep a process running
 YARN_DEV_RESTART="${YARN_DEV_ONSTART}"
+# overwrite the `yarn dev` command
+# example: `yarn watch`
+YARN_DEV_COMMAND="yarn dev"
 
 #? QUEUE WORKER
 # Run on startup

--- a/runtime/8.1/supervisor/supervisord.conf
+++ b/runtime/8.1/supervisor/supervisord.conf
@@ -47,7 +47,7 @@
 [program:yarn-dev]
     process_name=%(program_name)s_%(process_num)02d
     directory=/var/www/html/
-    command=yarn dev
+    command=%(ENV_YARN_DEV_COMMAND)s
     autostart=%(ENV_YARN_DEV_ONSTART)s
     autorestart=%(ENV_YARN_DEV_RESTART)s
     user=root


### PR DESCRIPTION
## Describe your changes
<!-- A brief about what your PR fixes, changes or adds. -->
Add an option to override the `yarn dev` from the `.env` file. It's helpful if the default dev command is something else like `yarn watch` in some cases.

## Issue ticket number and link (if available)
<!-- Mention the GitHub/Jira Issue Number this PR addresses -->


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have updated the `README.md` File (if needed).
- [x] Will this be part of a product update? If yes, please write one phrase about this update.

## Description (AI)

* **Introduced New Environment Variable `YARN_DEV_COMMAND`**
This update adds a new environment variable named `YARN_DEV_COMMAND` into a couple of files (`docker-compose.yml` and `example.env`). An environment variable is a way to pass on customized settings that the system will use to run applications properly.

* **Modification in `supervisord.conf` File**
The command in the `[program:yarn-dev]` section of `supervisord.conf` file has been revised. This configuration file is used to control how a program named Supervisor (a process manager) runs. Changes in this file mean adjustments on how applications under its control will operate.